### PR TITLE
Use the first LTS parent POM which allows compilation under Java 7.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.410</version>
+        <version>1.424</version>
     </parent>
 
     <artifactId>ivy</artifactId>


### PR DESCRIPTION
Should allow this to be checked in BuildHive, for example.
