### PR TITLE
Allow absolute paths to be used for properties files

### DIFF
--- a/src/main/java/hudson/ivy/IvyModuleSetBuild.java
+++ b/src/main/java/hudson/ivy/IvyModuleSetBuild.java
@@ -848,7 +848,12 @@ public class IvyModuleSetBuild extends AbstractIvyBuild<IvyModuleSet, IvyModuleS
                 for (String file : ivySettingsPropertyFiles.split(",")) {
                     File propertyFile = new File(workspaceProper, file.trim());
                     if (!propertyFile.exists()) {
-                        throw new AbortException(Messages.IvyModuleSetBuild_NoSuchPropertyFile(propertyFile.getAbsolutePath()));
+                    	logger.println("Property file not found in workspace at " + propertyFile.getAbsolutePath() + ". Attempting to use absolute path...");
+                    	propertyFile = new File(file.trim());
+                    	if(!propertyFile.exists())
+                    	{
+                    		throw new AbortException(Messages.IvyModuleSetBuild_NoSuchPropertyFile(propertyFile.getAbsolutePath()));
+                    	}
                     }
                     propertyFiles.add(propertyFile);
                 }

--- a/src/main/resources/hudson/ivy/IvyModuleSet/help-ivySettingsPropertyFiles.html
+++ b/src/main/resources/hudson/ivy/IvyModuleSet/help-ivySettingsPropertyFiles.html
@@ -26,7 +26,7 @@ THE SOFTWARE.
   <p>
   Property files that need to be loaded before parsing the Ivy settings
   file and Ivy module descriptors. Specified as comma-delimited list of
-  relative paths from the workspace root.
+  relative paths from the workspace root or absolute file paths.
   
   <p>
   This only needs to be specified if you use ${property} references in


### PR DESCRIPTION
If property file can't be loaded from the workspace for Ivy Builds assume the path is absolute and attempt to load again. This allows an Ivy Build to specify an absolute path for properties files. The help text has been updated to
communicate this as well.

I have been using this change on my fork for about a month and had no issues.
