### PR TITLE
[FIXED JENKINS-22447] Fix workspace lock release for ivy build

### DIFF
--- a/src/main/java/hudson/ivy/IvyBuild.java
+++ b/src/main/java/hudson/ivy/IvyBuild.java
@@ -468,6 +468,8 @@ public class IvyBuild extends AbstractIvyBuild<IvyModule, IvyBuild> {
 
         @Override
         public void cleanUp(BuildListener listener) throws Exception {
+            super.cleanUp(listener);
+            
             // at this point it's too late to mark the build as a failure, so ignore return value.
             performAllBuildSteps(listener, reporters,false);
             performAllBuildSteps(listener, project.getProperties(),false);

--- a/src/main/java/hudson/ivy/IvyModuleSetBuild.java
+++ b/src/main/java/hudson/ivy/IvyModuleSetBuild.java
@@ -612,6 +612,8 @@ public class IvyModuleSetBuild extends AbstractIvyBuild<IvyModuleSet, IvyModuleS
 
         @Override
         public void cleanUp(BuildListener listener) throws Exception {
+            super.cleanUp(listener);
+        
             if (project.isAggregatorStyleBuild()) {
                 // schedule downstream builds. for non aggregator style builds,
                 // this is done by each module


### PR DESCRIPTION
Call AbstractRunner's cleanUp to release workspace locks
