### PR TITLE
fixed JENKINS-13440

### DIFF
--- a/src/main/java/hudson/ivy/IvyBuild.java
+++ b/src/main/java/hudson/ivy/IvyBuild.java
@@ -410,7 +410,8 @@ public class IvyBuild extends AbstractIvyBuild<IvyModule, IvyBuild> {
         @Override
         protected Lease decideWorkspace(Node n, WorkspaceList wsl) throws InterruptedException, IOException {
             String pathToModuleRoot = IvyBuild.this.getProject().getRelativePathToModuleRoot();
-            return wsl.allocate(getModuleSetBuild().getModuleRoot().child(pathToModuleRoot));
+            // 2015-11-25 Matthias Bechtold: changed base path to workspace folder - fixes JENKINS-13440
+            return wsl.allocate(getModuleSetBuild().getWorkspace().child(pathToModuleRoot));
         }
 
         @Override

--- a/src/main/java/hudson/ivy/IvyModuleSetBuild.java
+++ b/src/main/java/hudson/ivy/IvyModuleSetBuild.java
@@ -530,11 +530,13 @@ public class IvyModuleSetBuild extends AbstractIvyBuild<IvyModuleSet, IvyModuleS
             logger.println("Parsing Ivy Descriptor Files");
 
             List<IvyModuleInfo> ivyDescriptors;
-            try {
-            	IvyXmlParser parser = new IvyXmlParser(listener, project, settings, getModuleRoot().getRemote());
-            	if (getModuleRoot().getChannel() instanceof Channel)
-            		((Channel) getModuleRoot().getChannel()).preloadJar(parser, Ivy.class);
-                ivyDescriptors = getModuleRoot().act(parser);
+            // 2015-11-25 Matthias Bechtold: Parse all modules in workspace rather than the first module's folder - fixes JENKINS-13440
+            FilePath moduleRoot = getModuleRoots().length>1 ? getModuleRoot().getParent() : getModuleRoot();
+            try { 
+            	IvyXmlParser parser = new IvyXmlParser(listener, project, settings, moduleRoot.getRemote());
+            	if (moduleRoot.getChannel() instanceof Channel)
+            		((Channel) moduleRoot.getChannel()).preloadJar(parser, Ivy.class);
+                ivyDescriptors = moduleRoot.act(parser);
             } catch (IOException e) {
                 if (e.getCause() instanceof AbortException)
                     throw (AbortException) e.getCause();


### PR DESCRIPTION
Expanded ivy.xml parser parameters to parse all checked out modules from Subversion SCM instead of the first one exclusively and adapted workspace path generation in builder class to set path correctly to /job/workspace/module#1 .../module#2 etc. Tested with Subversion SCM, checking out multiple modules into a job and Ivy/Ant installed on Jenkins.