### PR TITLE
Update to latest config file provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ work
 .gradle/
 build/
 .idea
+classes

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 work
 .gradle/
 build/
+.idea

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ compileJava {
 }
 
 dependencies {
-    jenkinsPlugins 'org.jenkins-ci.plugins:config-file-provider:2.14.1-beta@jar'
+    jenkinsPlugins 'org.jenkins-ci.plugins:config-file-provider:2.15@jar'
     jenkinsPlugins 'org.jenkins-ci.plugins:ant:1.2@jar'
     jenkinsPlugins 'org.jenkins-ci.plugins:junit:1.18@jar'
     optionalJenkinsPlugins 'org.jvnet.hudson.plugins:nant:1.4.1@jar'

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ compileJava {
 }
 
 dependencies {
-    jenkinsPlugins 'org.jenkins-ci.plugins:config-file-provider:2.14-beta@jar'
+    jenkinsPlugins 'org.jenkins-ci.plugins:config-file-provider:2.14.1-beta@jar'
     jenkinsPlugins 'org.jenkins-ci.plugins:ant:1.2@jar'
     jenkinsPlugins 'org.jenkins-ci.plugins:junit:1.18@jar'
     optionalJenkinsPlugins 'org.jvnet.hudson.plugins:nant:1.4.1@jar'

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ compileJava {
 }
 
 dependencies {
-    jenkinsPlugins 'org.jenkins-ci.plugins:config-file-provider:2.14-SNAPSHOT@jar'
+    jenkinsPlugins 'org.jenkins-ci.plugins:config-file-provider:2.14-beta@jar'
     jenkinsPlugins 'org.jenkins-ci.plugins:ant:1.2@jar'
     jenkinsPlugins 'org.jenkins-ci.plugins:junit:1.18@jar'
     optionalJenkinsPlugins 'org.jvnet.hudson.plugins:nant:1.4.1@jar'

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ group = "org.jenkins-ci.plugins"
 description = "A description of your plugin"
 
 jenkinsPlugin {
-    coreVersion = '1.491'
+    coreVersion = '1.642.3'
     displayName = 'Ivy Plugin'
     url = 'https://wiki.jenkins-ci.org/display/JENKINS/Ivy+Plugin'
     gitHubUrl = 'https://github.com/jenkinsci/ivy-plugin'
@@ -56,8 +56,9 @@ compileJava {
 }
 
 dependencies {
-    jenkinsPlugins 'org.jenkins-ci.plugins:config-file-provider:2.7.5@jar'
+    jenkinsPlugins 'org.jenkins-ci.plugins:config-file-provider:2.14-SNAPSHOT@jar'
     jenkinsPlugins 'org.jenkins-ci.plugins:ant:1.2@jar'
+    jenkinsPlugins 'org.jenkins-ci.plugins:junit:1.18@jar'
     optionalJenkinsPlugins 'org.jvnet.hudson.plugins:nant:1.4.1@jar'
     
     compile 'uk.com.robust-it:cloning:1.7.4'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Sep 24 07:55:34 EDT 2015
+#Mon Oct 10 17:59:56 CEST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.7-all.zip

--- a/src/main/java/hudson/ivy/IvyBuildProxy.java
+++ b/src/main/java/hudson/ivy/IvyBuildProxy.java
@@ -27,6 +27,7 @@ import hudson.FilePath;
 import hudson.model.Result;
 import hudson.remoting.Callable;
 import hudson.remoting.DelegatingCallable;
+import jenkins.security.MasterToSlaveCallable;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -217,7 +218,7 @@ public interface IvyBuildProxy {
         /**
          * {@link Callable} for invoking {@link BuildCallable} asynchronously.
          */
-        protected static final class AsyncInvoker implements DelegatingCallable<Object,Throwable> {
+        protected static final class AsyncInvoker extends MasterToSlaveCallable<Object, Throwable> implements DelegatingCallable<Object, Throwable> {
             private final IvyBuildProxy proxy;
             private final BuildCallable<?,?> program;
 

--- a/src/main/java/hudson/ivy/IvyBuilder.java
+++ b/src/main/java/hudson/ivy/IvyBuilder.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
+import jenkins.security.MasterToSlaveCallable;
 import org.apache.tools.ant.BuildEvent;
 
 /**
@@ -51,7 +52,7 @@ import org.apache.tools.ant.BuildEvent;
  *
  * @author Timothy Bingaman
  */
-public abstract class IvyBuilder implements DelegatingCallable<Result,IOException> {
+public abstract class IvyBuilder extends MasterToSlaveCallable<Result, IOException> implements DelegatingCallable<Result, IOException> {
     /**
      * Goals to be executed in this Ant execution.
      */

--- a/src/main/java/hudson/ivy/IvyConfig.java
+++ b/src/main/java/hudson/ivy/IvyConfig.java
@@ -21,7 +21,7 @@ public class IvyConfig extends XmlConfig {
     }
 
     public IvyConfig(Config config) {
-        super(config);
+        super(config.id, config.name, config.comment, config.content, config.getProviderId() == null ? provider.getProviderId() : config.getProviderId());
     }
 
     @Extension

--- a/src/main/java/hudson/ivy/IvyConfig.java
+++ b/src/main/java/hudson/ivy/IvyConfig.java
@@ -2,7 +2,9 @@ package hudson.ivy;
 
 import hudson.Extension;
 import org.jenkinsci.lib.configprovider.model.Config;
+import org.jenkinsci.plugins.configfiles.custom.CustomConfig;
 import org.jenkinsci.plugins.configfiles.xml.XmlConfig;
+import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
@@ -13,6 +15,15 @@ public class IvyConfig extends XmlConfig {
         super(id, name, comment, content);
     }
 
+    @DataBoundConstructor
+    public IvyConfig(String id, String name, String comment, String content, String providerId) {
+        super(id, name, comment, content, providerId);
+    }
+
+    public IvyConfig(Config config) {
+        super(config);
+    }
+
     @Extension
     public static final XmlConfigProvider provider = new XmlConfigProvider() {
         @Override
@@ -21,9 +32,20 @@ public class IvyConfig extends XmlConfig {
         }
 
         @Override
-        public Config newConfig() {
+        public IvyConfig newConfig() {
             String id = getProviderId() + System.currentTimeMillis();
-            return new Config(id, "IvyConfig", "", "<ivysettings>\n</ivysettings>");
+            return new IvyConfig(id, "IvyConfig", "", "<ivysettings>\n</ivysettings>");
         }
+
+        @Override
+        public Config newConfig(String id) {
+            return new IvyConfig(id, "IvyConfig", "", "<ivysettings>\n</ivysettings>", getProviderId());
+        }
+
+        @Override
+        public <T extends Config> T convert(Config config) {
+            return (T) new IvyConfig(config);
+        }
+
     };
 }

--- a/src/main/java/hudson/ivy/IvyModule.java
+++ b/src/main/java/hudson/ivy/IvyModule.java
@@ -167,7 +167,7 @@ public final class IvyModule extends AbstractIvyProject<IvyModule, IvyBuild> imp
                     cloner.dontClone(Descriptor.class);
                     getBuildWrappersList().add(cloner.deepClone(buildWrapper));
                 }
-                catch(IOException e)
+                catch(Exception e)
                 {
                     throw new RuntimeException("Could not copy build wrappers", e);
                 }
@@ -298,7 +298,7 @@ public final class IvyModule extends AbstractIvyProject<IvyModule, IvyBuild> imp
         DescribableList<Publisher, Descriptor<Publisher>> publishersList = new DescribableList<Publisher, Descriptor<Publisher>>(Saveable.NOOP);
         try {
             publishersList.addAll(createModulePublishers());
-        } catch (IOException e) {
+        } catch (Exception e) {
             LOGGER.warning("Failed to load module publisher list");
         }
         return publishersList;

--- a/src/main/java/hudson/ivy/IvyModuleSet.java
+++ b/src/main/java/hudson/ivy/IvyModuleSet.java
@@ -81,6 +81,7 @@ import hudson.util.ListBoxModel;
 import net.sf.json.JSONObject;
 
 import org.jenkinsci.lib.configprovider.model.Config;
+import org.jenkinsci.plugins.configfiles.ConfigFiles;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
@@ -807,7 +808,7 @@ public final class IvyModuleSet extends AbstractIvyProject<IvyModuleSet,IvyModul
         public ListBoxModel doFillSettingsItems(@AncestorInPath ItemGroup context) {
             System.out.println(">"+context);
             System.out.println(">>"+IvyConfig.provider.getClass());
-            List<Config> configsInContext = Config.getConfigsInContext(context, null);
+            List<Config> configsInContext = ConfigFiles.getConfigsInContext(context, null);
             System.out.println(">>>"+configsInContext);
             ListBoxModel lb = new ListBoxModel();
             lb.add("please select", "");

--- a/src/main/java/hudson/ivy/IvyModuleSet.java
+++ b/src/main/java/hudson/ivy/IvyModuleSet.java
@@ -81,6 +81,7 @@ import hudson.util.ListBoxModel;
 import net.sf.json.JSONObject;
 
 import org.jenkinsci.lib.configprovider.model.Config;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
@@ -803,9 +804,14 @@ public final class IvyModuleSet extends AbstractIvyProject<IvyModuleSet,IvyModul
             save();
         }
 
-        public ListBoxModel doFillSettingsItems() {
+        public ListBoxModel doFillSettingsItems(@AncestorInPath ItemGroup context) {
+            System.out.println(">"+context);
+            System.out.println(">>"+IvyConfig.provider.getClass());
+            List<Config> configsInContext = Config.getConfigsInContext(context, null);
+            System.out.println(">>>"+configsInContext);
             ListBoxModel lb = new ListBoxModel();
-            for (Config config : IvyConfig.provider.getAllConfigs()) {
+            lb.add("please select", "");
+            for (Config config : configsInContext) {
                 lb.add(config.name, config.id);
             }
             return lb;

--- a/src/main/java/hudson/ivy/IvyModuleSet.java
+++ b/src/main/java/hudson/ivy/IvyModuleSet.java
@@ -806,10 +806,7 @@ public final class IvyModuleSet extends AbstractIvyProject<IvyModuleSet,IvyModul
         }
 
         public ListBoxModel doFillSettingsItems(@AncestorInPath ItemGroup context) {
-            System.out.println(">"+context);
-            System.out.println(">>"+IvyConfig.provider.getClass());
             List<Config> configsInContext = ConfigFiles.getConfigsInContext(context, null);
-            System.out.println(">>>"+configsInContext);
             ListBoxModel lb = new ListBoxModel();
             lb.add("please select", "");
             for (Config config : configsInContext) {

--- a/src/main/java/hudson/ivy/IvyModuleSetBuild.java
+++ b/src/main/java/hudson/ivy/IvyModuleSetBuild.java
@@ -64,6 +64,7 @@ import org.apache.ivy.util.Message;
 import org.apache.tools.ant.BuildEvent;
 import org.apache.tools.ant.types.FileSet;
 import org.jenkinsci.lib.configprovider.model.Config;
+import org.jenkinsci.plugins.configfiles.ConfigFiles;
 import org.jenkinsci.plugins.configfiles.common.CleanTempFilesAction;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
@@ -354,7 +355,7 @@ public class IvyModuleSetBuild extends AbstractIvyBuild<IvyModuleSet, IvyModuleS
                 EnvVars envVars = getEnvironment(listener);
 
                 Queue.Executable currentExecutable = Executor.currentExecutor().getCurrentExecutable();
-                Config config = Config.getByIdOrNull((Run<?, ?>) currentExecutable, project.getSettings());
+                Config config = ConfigFiles.getByIdOrNull((Run<?, ?>) currentExecutable, project.getSettings());
                 if (config != null) {
                     FilePath tmp = getWorkspace().createTextTempFile("ivy", "xml", config.content);
                     settings = tmp.getRemote();

--- a/src/main/java/hudson/ivy/IvyModuleSetBuild.java
+++ b/src/main/java/hudson/ivy/IvyModuleSetBuild.java
@@ -30,18 +30,8 @@ import hudson.Launcher;
 import hudson.Util;
 import hudson.ivy.IvyBuild.ProxyImpl2;
 import hudson.ivy.builder.IvyBuilderType;
-import hudson.model.AbstractProject;
-import hudson.model.Action;
-import hudson.model.Build;
-import hudson.model.BuildListener;
-import hudson.model.DependencyGraph;
-import hudson.model.Environment;
-import hudson.model.Fingerprint;
-import hudson.model.Hudson;
-import hudson.model.ParametersAction;
-import hudson.model.Result;
-import hudson.model.Run;
-import hudson.model.TaskListener;
+import hudson.model.*;
+import hudson.model.Queue;
 import hudson.remoting.Callable;
 import hudson.remoting.Channel;
 import hudson.scm.ChangeLogSet;
@@ -61,6 +51,7 @@ import java.util.Map.Entry;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import jenkins.security.MasterToSlaveCallable;
 import org.apache.commons.lang.StringUtils;
 import org.apache.ivy.Ivy;
 import org.apache.ivy.Ivy.IvyCallback;
@@ -362,7 +353,8 @@ public class IvyModuleSetBuild extends AbstractIvyBuild<IvyModuleSet, IvyModuleS
             try {
                 EnvVars envVars = getEnvironment(listener);
 
-                Config config = IvyConfig.provider.getConfigById(project.getSettings());
+                Queue.Executable currentExecutable = Executor.currentExecutor().getCurrentExecutable();
+                Config config = Config.getByIdOrNull((Run<?, ?>) currentExecutable, project.getSettings());
                 if (config != null) {
                     FilePath tmp = getWorkspace().createTextTempFile("ivy", "xml", config.content);
                     settings = tmp.getRemote();
@@ -756,7 +748,7 @@ public class IvyModuleSetBuild extends AbstractIvyBuild<IvyModuleSet, IvyModuleS
      * Executed on the slave to parse ivy.xml files and extract information into
      * {@link IvyModuleInfo}, which will be then brought back to the master.
      */
-    private static final class IvyXmlParser implements Callable<List<IvyModuleInfo>, Throwable> {
+    private static final class IvyXmlParser extends MasterToSlaveCallable<List<IvyModuleInfo>, Throwable> implements Callable<List<IvyModuleInfo>, Throwable> {
         private static final String IVY_XML_PATTERN = "**/ivy.xml";
         private final BuildListener listener;
         /**
@@ -840,7 +832,7 @@ public class IvyModuleSetBuild extends AbstractIvyBuild<IvyModuleSet, IvyModuleS
          * @throws AbortException 
          *
          * @throws ParseException
-         * @throws IOException
+         * @throws AbortException
          */
         public Ivy getIvy(PrintStream logger) throws AbortException {
             Message.setDefaultLogger(new IvyMessageImpl());
@@ -905,7 +897,7 @@ public class IvyModuleSetBuild extends AbstractIvyBuild<IvyModuleSet, IvyModuleS
         return super.getParent();
     }
 
-    private static final class IvyPreloadTask implements Callable<Boolean, IOException> {
+    private static final class IvyPreloadTask extends MasterToSlaveCallable<Boolean, IOException> implements Callable<Boolean, IOException> {
 		private static final long serialVersionUID = 1L;
 
 		public Boolean call() throws IOException {


### PR DESCRIPTION
This should solve the following issues:

https://issues.jenkins-ci.org/browse/JENKINS-37046
https://issues.jenkins-ci.org/browse/JENKINS-35139
https://issues.jenkins-ci.org/browse/JENKINS-34192

please note: the config-file-provider integration for the ivy-plugin was never done in a proper way (In fact it never worked). Therefore it is not possible to migrate the old configuration to the new required format.

This PR depends on the 2.14-beta version of the config-file-provider-plugin. Please test it with this one and hold the proper release until I released the config-file-provider-plugin with a stable version.