### PR TITLE
[JENKINS-41129] Prevent null pointer dereference

### DIFF
--- a/src/main/java/hudson/ivy/IvyModuleSetBuild.java
+++ b/src/main/java/hudson/ivy/IvyModuleSetBuild.java
@@ -355,7 +355,10 @@ public class IvyModuleSetBuild extends AbstractIvyBuild<IvyModuleSet, IvyModuleS
                 EnvVars envVars = getEnvironment(listener);
 
                 Queue.Executable currentExecutable = Executor.currentExecutor().getCurrentExecutable();
-                Config config = ConfigFiles.getByIdOrNull((Run<?, ?>) currentExecutable, project.getSettings());
+                Config config = null;
+                if (project.getSettings() != null) {
+                    config = ConfigFiles.getByIdOrNull((Run<?, ?>) currentExecutable, project.getSettings());
+                }
                 if (config != null) {
                     FilePath tmp = getWorkspace().createTextTempFile("ivy", "xml", config.content);
                     settings = tmp.getRemote();


### PR DESCRIPTION
If project has no specific settings defined then building an Ivy project results in an NPE:

```
12:44:48 ERROR: Processing failed due to a bug in the code. Please report this to users@hudson.dev.java.net
12:44:48 java.lang.NullPointerException
12:44:48 	at org.jenkinsci.plugins.configfiles.GlobalConfigFiles.getById(GlobalConfigFiles.java:99)
12:44:48 	at org.jenkinsci.plugins.configfiles.ConfigFiles.getByIdOrNull(ConfigFiles.java:87)
12:44:48 	at org.jenkinsci.plugins.configfiles.ConfigFiles.getByIdOrNull(ConfigFiles.java:116)
12:44:48 	at hudson.ivy.IvyModuleSetBuild$RunnerImpl.doRun(IvyModuleSetBuild.java:358)
12:44:48 	at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:534)
12:44:48 	at hudson.model.Run.execute(Run.java:1728)
12:44:48 	at hudson.model.Run.run(Run.java:1687)
12:44:48 	at hudson.ivy.IvyModuleSetBuild.run(IvyModuleSetBuild.java:273)
12:44:48 	at hudson.model.ResourceController.execute(ResourceController.java:98)
12:44:48 	at hudson.model.Executor.run(Executor.java:404)
12:44:48 project=hudson.ivy.IvyModuleSet@36558693[devOps/tulip]
12:44:48 project.getModules()=[]
12:44:48 FATAL: null
12:44:48 java.lang.NullPointerException
12:44:48 	at org.jenkinsci.plugins.configfiles.GlobalConfigFiles.getById(GlobalConfigFiles.java:99)
12:44:48 	at org.jenkinsci.plugins.configfiles.ConfigFiles.getByIdOrNull(ConfigFiles.java:87)
12:44:48 	at org.jenkinsci.plugins.configfiles.ConfigFiles.getByIdOrNull(ConfigFiles.java:116)
12:44:48 	at hudson.ivy.IvyModuleSetBuild$RunnerImpl.doRun(IvyModuleSetBuild.java:358)
12:44:48 	at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:534)
12:44:48 	at hudson.model.Run.execute(Run.java:1728)
12:44:48 	at hudson.model.Run.run(Run.java:1687)
12:44:48 	at hudson.ivy.IvyModuleSetBuild.run(IvyModuleSetBuild.java:273)
12:44:48 	at hudson.model.ResourceController.execute(ResourceController.java:98)
12:44:48 	at hudson.model.Executor.run(Executor.java:404)
```

https://issues.jenkins-ci.org/browse/JENKINS-41129