### PR TITLE
[FIXED JENKINS-47778] Not manage the order in Jenkins Global Configuration

### DIFF
--- a/src/main/java/hudson/ivy/IvyModuleSet.java
+++ b/src/main/java/hudson/ivy/IvyModuleSet.java
@@ -782,7 +782,7 @@ public final class IvyModuleSet extends AbstractIvyProject<IvyModuleSet,IvyModul
         return DESCRIPTOR;
     }
 
-    @Extension(ordinal=890)
+    @Extension
     public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
 
     public static final class DescriptorImpl extends AbstractProjectDescriptor {


### PR DESCRIPTION
In the latest Jenkins core version, the* ivy-project plugin* is not being correctly rendered in the UI Jenkins Global Configuration - the same is happening with the maven plugin by the way.

The problem seems to come from @Extension(ordinal=890). As per Extension documentation

> Used for sorting extensions. Extensions will be sorted in the descending order of the ordinal. In other words, the extensions with the highest numbers will be chosen first. This is a rather poor approach to the problem, so its use is generally discouraged.

* https://issues.jenkins-ci.org/browse/JENKINS-47778