### PR TITLE
Do dependency graph rebuilding async on config submit

### DIFF
--- a/src/main/java/hudson/ivy/IvyBuildTrigger.java
+++ b/src/main/java/hudson/ivy/IvyBuildTrigger.java
@@ -803,7 +803,7 @@ public class IvyBuildTrigger extends Notifier implements DependecyDeclarer {
 
             save();
             invalidateProjectMap();
-            Hudson.getInstance().rebuildDependencyGraph();
+            Hudson.getInstance().rebuildDependencyGraphAsync();
             return r;
         }
 


### PR DESCRIPTION
On large Jenkins instances, rebuilding the dependency graph can take a
lot of time and saving the Jenkins main configuration page might end up
in a timeout when using the ivy plugin.

This fix will keep the configuration submit at the Jenkins main
configuration responsive.