### PR TITLE
Fix #34: Add missing descriptor for IvyConfiguration

### DIFF
--- a/src/main/java/hudson/ivy/IvyBuildTrigger.java
+++ b/src/main/java/hudson/ivy/IvyBuildTrigger.java
@@ -27,6 +27,7 @@ import hudson.Util;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.BuildListener;
 import hudson.model.DependencyGraph;
+import hudson.model.Descriptor;
 import hudson.model.Item;
 import hudson.model.PersistentDescriptor;
 import hudson.model.Result;
@@ -639,6 +640,9 @@ public class IvyBuildTrigger extends Notifier implements DependencyDeclarer {
         public boolean getExists() {
             return new File(ivyConfPath).exists();
         }
+
+        @Extension
+        public static class DescriptorImpl extends Descriptor<IvyConfiguration> {}
     }
 
     /**


### PR DESCRIPTION
It was missed when implementing JCasC compatibility (commit 9272245acc2dc0f2d1cef4f7ca99b30706c6e60d).

This fixes the stacktrace being logged to the Jenkins log when a user opened the global config page at http://<jenkins>/configure. This was only a warning and should not have had any functional impact.

For more details see: https://jenkins.io/redirect/developer/class-is-missing-descriptor