### PR TITLE
Upgrade Ivy to 2.5.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,9 +60,9 @@ dependencies {
     jenkinsTest 'org.jenkins-ci.main:jenkins-test-harness:2.48'
 
     implementation 'uk.com.robust-it:cloning:1.9.12'
-    implementation 'org.apache.ivy:ivy:2.4.0'
-    implementation 'com.jcraft:jsch:0.1.54'
-    implementation('commons-vfs:commons-vfs:1.0') {
+    implementation 'org.apache.ivy:ivy:2.5.0'
+    implementation 'com.jcraft:jsch:0.1.55'
+    implementation('org.apache.commons:commons-vfs2:2.2') {
         exclude group: 'commons-logging', module: 'commons-logging'
     }
 }


### PR DESCRIPTION
This is to get the latest features & fixes.

The libraries "jsch" and "commons-vfs2" are dependencies of Ivy and packaged with Ivy in the "binary-with-dependencies" distribution with exactly the versions specified.

For details see https://ant.apache.org/ivy/history/2.5.0/release-notes.html.