### PR TITLE
Convert Markdown to Asciidoc, add badges

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -8,4 +8,4 @@ image:https://ci.jenkins.io/job/Plugins/job/ivy-plugin/job/master/badge/icon[Bui
 
 Provides Jenkins integration with http://ant.apache.org/ivy/[Apache Ivy].
 
-See http://wiki.jenkins-ci.org/display/JENKINS/Ivy+Plugin[Ivy Plugin] on the Jenkins wiki for more information.
+See https://plugins.jenkins.io/ivy/[Ivy Plugin] on the Jenkins wiki for more information.

--- a/README.adoc
+++ b/README.adoc
@@ -1,0 +1,11 @@
+[[ivy-plugin]]
+= ivy-plugin
+
+image:https://img.shields.io/jenkins/plugin/v/ivy.svg[Jenkins Plugin,link=https://plugins.jenkins.io/ivy]
+image:https://img.shields.io/github/release/jenkinsci/ivy-plugin.svg?label=release[GitHub release,link=https://github.com/jenkinsci/ivy-plugin/releases/latest]
+image:https://img.shields.io/jenkins/plugin/i/ivy.svg?color=blue[Jenkins Plugin Installs,link=https://plugins.jenkins.io/ivy]
+image:https://ci.jenkins.io/job/Plugins/job/ivy-plugin/job/master/badge/icon[Build Status,link=https://ci.jenkins.io/job/Plugins/job/ivy-plugin/job/master/]
+
+Provides Jenkins integration with http://ant.apache.org/ivy/[Apache Ivy].
+
+See http://wiki.jenkins-ci.org/display/JENKINS/Ivy+Plugin[Ivy Plugin] on the Jenkins wiki for more information.

--- a/README.markdown
+++ b/README.markdown
@@ -1,6 +1,0 @@
-Jenkins Ivy Plugin
-==================
-
-Provides Jenkins integration with [Apache Ivy](http://ant.apache.org/ivy/).
-
-See [Ivy Plugin](http://wiki.jenkins-ci.org/display/JENKINS/Ivy+Plugin) on the Jenkins wiki for more information.


### PR DESCRIPTION
This is part of the effort to make documentation more attractive to users and developers. I think the agreed upon standard for Jenkins is moving towards Asciidoc instead of Markdown.