### PR TITLE
Adapt icon removal from core

### DIFF
--- a/src/main/resources/hudson/ivy/IvyModuleSet/actions.jelly
+++ b/src/main/resources/hudson/ivy/IvyModuleSet/actions.jelly
@@ -23,10 +23,10 @@ THE SOFTWARE.
 -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
   <j:if test="${it.hasDisabledModule()}">
     <l:isAdmin>
-      <l:task icon="images/24x24/delete-document.gif" href="deleteAllDisabledModules" title="${%Delete All Disabled Modules}"/>
+      <l:task icon="icon-delete-document icon-md" href="deleteAllDisabledModules" title="${%Delete All Disabled Modules}"/>
     </l:isAdmin>
   </j:if>
   <j:set var="url" value="${h.getNearestAncestorUrl(request,it)}"/>

--- a/src/main/resources/hudson/ivy/IvyModuleSet/index.jelly
+++ b/src/main/resources/hudson/ivy/IvyModuleSet/index.jelly
@@ -38,20 +38,20 @@ THE SOFTWARE.
             ${act.displayName}
           </t:summary>
         </j:forEach>
-        <t:summary icon="folder.gif" href="ws/" permission="${it.WORKSPACE}">
+        <t:summary icon="folder.png" href="ws/" permission="${it.WORKSPACE}">
           ${%Workspace}
         </t:summary>
 
         <t:artifactList caption="${%Last Successful Artifacts}"
             build="${it.lastSuccessfulBuild}" baseURL="lastSuccessfulBuild/"/>
 
-        <t:summary icon="notepad.gif" href="changes">
+        <t:summary icon="notepad.png" href="changes">
           ${%Recent Changes}
         </t:summary>
 
         <j:set var="tr" value="${it.testResultAction}"/>
         <j:if test="${tr!=null}">
-          <t:summary icon="clipboard.gif">
+          <t:summary icon="clipboard.png">
             <a href="lastBuild/testReport/">${%Latest Test Result}</a>
             <t:test-result it="${tr}"/>
           </t:summary>


### PR DESCRIPTION
The change proposed prepares the plugin for the icon path removal from core in the upcoming LTS line. This change affects plugins not using the icon API or relying on paths. Plugins using the API properly in the first place are unaffected by this change.

Could you trigger a release after merging this PR please, giving people a chance to update the plugin before updating to the next LTS version @arothian 
Thanks in advance!