### PR TITLE
Replace Prototype.js with native JavaScript

### DIFF
--- a/src/main/resources/hudson/ivy/IvyModuleSet/modules.jelly
+++ b/src/main/resources/hudson/ivy/IvyModuleSet/modules.jelly
@@ -39,7 +39,10 @@ THE SOFTWARE.
               <div>
                 <script>
                   function build(a) {
-                    new Ajax.Request(a.href);
+                    fetch(a.href, {
+                        method: "post",
+                        headers: crumb.wrap({}),
+                    });
                     hoverNotification('${%Build scheduled}',a);
                     return false;
                   }


### PR DESCRIPTION
See [JENKINS-70906](https://issues.jenkins.io/browse/JENKINS-70906). Jenkins core currently uses [Prototype 1.7](https://github.com/prototypejs/prototype/releases/tag/1.7), released on November 15, 2010. The latest version is [Prototype 1.7.3](https://github.com/prototypejs/prototype/releases/tag/1.7.3), released on September 22, 2015. When an attempt was made to upgrade to 1.7.3 in 2018 in [JENKINS-49319](https://issues.jenkins.io/browse/JENKINS-49319), the change had to be reverted. Since this library has been unmaintained for the past 8 years, this PR removes any usages of it in favor of native JavaScript APIs.