### PR TITLE
Require Jenkins 2.426.3 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
   <properties>
     <revision>2.6</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.375.4</jenkins.version>
+    <jenkins.version>2.426.3</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <!-- TODO fix violations -->
     <spotbugs.threshold>High</spotbugs.threshold>
@@ -57,8 +57,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.375.x</artifactId>
-        <version>2198.v39c76fc308ca</version>
+        <artifactId>bom-2.426.x</artifactId>
+        <version>3023.v02a_987a_b_3ff9</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -30,26 +30,9 @@
 
   <developers>
     <developer>
-      <id>hibou</id>
-    </developer>
-    <developer>
-      <id>martinficker</id>
-      <name>Martin Ficker</name>
-    </developer>
-    <developer>
-      <id>jmetcalf</id>
-    </developer>
-    <developer>
-      <id>tbingaman</id>
-      <name>Timothy Bingaman</name>
-    </developer>
-    <developer>
-      <id>gboissinot</id>
-      <name>Gregory Boissinot</name>
-    </developer>
-    <developer>
-      <id>arothian</id>
-      <name>Kevin Formsma</name>
+      <id>markewaite</id>
+      <name>Mark Waite</name>
+      <email>mark.earl.waite@gmail.com</email>
     </developer>
   </developers>
 

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>design.aem</groupId>
+      <artifactId>cloning</artifactId>
+      <version>1.11.1</version>
+    </dependency>
+    <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>commons-lang3-api</artifactId>
     </dependency>
@@ -133,11 +138,6 @@
       <artifactId>nant</artifactId>
       <version>248.vcc8a_3eec8db_a</version>
       <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>uk.com.robust-it</groupId>
-      <artifactId>cloning</artifactId>
-      <version>1.9.12</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -80,11 +80,6 @@
       <artifactId>commons-vfs2</artifactId>
       <version>2.9.0</version>
       <exclusions>
-        <!-- Provided by commons-lang3-api plugin -->
-        <exclusion>
-          <groupId>org.apache.commons</groupId>
-          <artifactId>commons-lang3</artifactId>
-        </exclusion>
         <exclusion>
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-hdfs-client</artifactId>


### PR DESCRIPTION
## Require Jenkins 2.426.3 or newer

[Installation statistics](https://stats.jenkins.io/pluginversions/ivy.html) show that 67% of the installations of the 2.5 release are already using Jenkins 2.426.3.

[SECURITY-3314](https://www.jenkins.io/security/advisory/2024-01-24/#SECURITY-3314) is a critical vulnerability that is resolved in 2.426.3.  The advisory recommends that all users upgrade to 2.426.3 or newer.

Users should upgrade to 2.426.3 and most of the users of the current release have already upgraded.

Also includes additional changes to reduce maintenance.

- d36bf2c46a25f220b870e365ba727893b72e9dd6 - Use deep cloning library 1.11.1 as released in 2022
- 36d058002b9719c0f8cb8b12e02bff36d55144ed - Remove maintainers that have exited
- fbfd544d2d9e34ee603901a67701ea95ab37d372 - Reduce commons-vfs2 exclusions

### Testing done

Automated tests pass.

Interactive testing not yet performed.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
