### PR TITLE
[SECURITY-3093] Require POST to delete modules - fix CSRF

### DIFF
--- a/src/main/java/hudson/ivy/IvyModuleSet.java
+++ b/src/main/java/hudson/ivy/IvyModuleSet.java
@@ -84,6 +84,7 @@ import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.verb.POST;
 
 /**
  * Group of {@link IvyModule}s.
@@ -744,6 +745,7 @@ public final class IvyModuleSet extends AbstractIvyProject<IvyModuleSet, IvyModu
     /**
      * Delete all disabled modules.
      */
+    @POST
     public void doDoDeleteAllDisabledModules(StaplerResponse rsp) throws IOException, InterruptedException {
         checkPermission(DELETE);
         for (IvyModule m : getDisabledModules(true)) {


### PR DESCRIPTION
## [SECURITY-3093] Require POST to delete modules - fix CSRF

[SECURITY-3093](https://www.jenkins.io/security/advisory/2023-09-06/#SECURITY-3093) reports that Ivy Plugin 2.5 and earlier does not require POST requests for an HTTP endpoint, resulting in a cross-site request forgery (CSRF) vulnerability.

This vulnerability allows attackers to delete disabled modules.

### Testing done

Automated tests pass.

Needs interactive test to confirm.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
