### PR TITLE
Require Jenkins 2.479.1 and Jakarta EE 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.88</version>
+    <version>5.6</version>
     <relativePath />
   </parent>
 
@@ -38,8 +38,8 @@
   <properties>
     <revision>2.9</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.baseline>2.452</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.4</jenkins.version>
+    <jenkins.baseline>2.479</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <!-- TODO fix violations -->
     <spotbugs.threshold>High</spotbugs.threshold>
@@ -51,7 +51,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>3944.v1a_e4f8b_452db_</version>
+        <version>4051.v78dce3ce8b_d6</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/java/hudson/ivy/IvyBuild.java
+++ b/src/main/java/hudson/ivy/IvyBuild.java
@@ -57,7 +57,7 @@ import java.util.Map;
 import org.apache.tools.ant.BuildEvent;
 import org.kohsuke.stapler.Ancestor;
 import org.kohsuke.stapler.Stapler;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 /**
  * {@link Run} for {@link IvyModule}.
@@ -85,7 +85,7 @@ public class IvyBuild extends AbstractIvyBuild<IvyModule, IvyBuild> {
 
     @Override
     public String getUpUrl() {
-        StaplerRequest req = Stapler.getCurrentRequest();
+        StaplerRequest2 req = Stapler.getCurrentRequest2();
         if (req != null) {
             List<Ancestor> ancs = req.getAncestors();
             for (int i = 1; i < ancs.size(); i++) {
@@ -102,7 +102,7 @@ public class IvyBuild extends AbstractIvyBuild<IvyModule, IvyBuild> {
 
     @Override
     public String getDisplayName() {
-        StaplerRequest req = Stapler.getCurrentRequest();
+        StaplerRequest2 req = Stapler.getCurrentRequest2();
         if (req != null) {
             List<Ancestor> ancs = req.getAncestors();
             for (int i = 1; i < ancs.size(); i++) {

--- a/src/main/java/hudson/ivy/IvyBuildTrigger.java
+++ b/src/main/java/hudson/ivy/IvyBuildTrigger.java
@@ -40,6 +40,7 @@ import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Notifier;
 import hudson.tasks.Publisher;
 import hudson.util.FormValidation;
+import jakarta.servlet.ServletException;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -52,7 +53,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.servlet.ServletException;
 import jenkins.model.DependencyDeclarer;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
@@ -70,8 +70,8 @@ import org.apache.ivy.util.Message;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 
 /**
  * Trigger the build of other project based on the Ivy dependency management system.
@@ -818,7 +818,7 @@ public class IvyBuildTrigger extends Notifier implements DependencyDeclarer {
          * Configure the Descriptor from a GUI request.
          */
         @Override
-        public boolean configure(StaplerRequest req, JSONObject json) {
+        public boolean configure(StaplerRequest2 req, JSONObject json) {
             try (BulkChange bc = new BulkChange(this)) {
                 configurations = new IvyConfiguration[0];
                 req.bindJSON(this, json);
@@ -839,9 +839,9 @@ public class IvyBuildTrigger extends Notifier implements DependencyDeclarer {
          * One such triggering event could be publish of a non-integration (milestone/release) build of the IvyBuildTrigger
          * managed project code to the Ivy repository that is visible to your build system.
          * <p>
-         * The StaplerRequest parameter must include request parameters <code>org</code> and <code>name</code>
+         * The StaplerRequest2 parameter must include request parameters <code>org</code> and <code>name</code>
          * which respectively represent the Ivy module descriptor attributes <code>organisation</code> and <code>module</code>.
-         * Optional request parameters that can be passed on the StaplerRequest include <code>branch</code> and <code>rev</code>
+         * Optional request parameters that can be passed on the StaplerRequest2 include <code>branch</code> and <code>rev</code>
          * which respectively represent the Ivy module descriptor attributes <code>branch</code> and <code>revision</code>.
          * These values are used to match against the ModuleDescriptor of Jenkins projects using the IvyBuildTrigger.  In the
          * case that more than one project matches, it is the first match that will win, and only that project will have
@@ -853,13 +853,13 @@ public class IvyBuildTrigger extends Notifier implements DependencyDeclarer {
          * dependent projects.  Successfully executing this event trigger requires global {@link Item#BUILD} permission on a
          * secured Jenkins instance.
          *
-         * @param req  The StaplerRequest
-         * @param rsp  The StaplerResponse
+         * @param req  The StaplerRequest2
+         * @param rsp  The StaplerResponse2
          * @throws IOException    IOException on the servlet call
          * @throws ServletException   ServletException on the servlet call
          * @see #isExtendedVersionMatching()
          */
-        public void doHandleExternalTrigger(StaplerRequest req, StaplerResponse rsp)
+        public void doHandleExternalTrigger(StaplerRequest2 req, StaplerResponse2 rsp)
                 throws IOException, ServletException {
             String org = Util.fixEmptyAndTrim(req.getParameter("org"));
             String name = Util.fixEmptyAndTrim(req.getParameter("name"));
@@ -983,7 +983,7 @@ public class IvyBuildTrigger extends Notifier implements DependencyDeclarer {
      * This cause is used when triggering downstream builds from the external event trigger.
      *
      * @author jmetcalf@dev.java.net
-     * @see hudson.ivy.IvyBuildTrigger.DescriptorImpl#doHandleExternalTrigger(StaplerRequest, StaplerResponse)
+     * @see hudson.ivy.IvyBuildTrigger.DescriptorImpl#doHandleExternalTrigger(StaplerRequest2, StaplerResponse2)
      */
     public static class UserCause extends Cause.UserIdCause {
 
@@ -992,7 +992,7 @@ public class IvyBuildTrigger extends Notifier implements DependencyDeclarer {
         /**
          * Constructor
          *
-         * @param ivylabel The Ivy ModuleRevisionId label computed from the StaplerRequest.
+         * @param ivylabel The Ivy ModuleRevisionId label computed from the StaplerRequest2.
          */
         public UserCause(String ivylabel) {
             this.ivylabel = ivylabel;

--- a/src/main/java/hudson/ivy/IvyModule.java
+++ b/src/main/java/hudson/ivy/IvyModule.java
@@ -46,6 +46,7 @@ import hudson.tasks.BuildWrapper;
 import hudson.tasks.LogRotator;
 import hudson.tasks.Publisher;
 import hudson.util.DescribableList;
+import jakarta.servlet.ServletException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -56,12 +57,11 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.servlet.ServletException;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
 import org.apache.ivy.core.module.id.ModuleRevisionId;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 import org.kohsuke.stapler.export.Exported;
 
 /**
@@ -572,7 +572,8 @@ public final class IvyModule extends AbstractIvyProject<IvyModule, IvyBuild> imp
     }
 
     @Override
-    protected void submit(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException, FormException {
+    protected void submit(StaplerRequest2 req, StaplerResponse2 rsp)
+            throws IOException, ServletException, FormException {
         super.submit(req, rsp);
 
         targets = Util.fixEmptyAndTrim(req.getParameter("targets"));

--- a/src/main/java/hudson/ivy/IvyModuleSet.java
+++ b/src/main/java/hudson/ivy/IvyModuleSet.java
@@ -63,6 +63,7 @@ import hudson.util.CopyOnWriteMap;
 import hudson.util.DescribableList;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
+import jakarta.servlet.ServletException;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -73,7 +74,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import javax.servlet.ServletException;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.jenkinsci.lib.configprovider.model.Config;
@@ -81,8 +81,8 @@ import org.jenkinsci.plugins.configfiles.ConfigFiles;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.verb.POST;
 
@@ -309,7 +309,7 @@ public final class IvyModuleSet extends AbstractIvyProject<IvyModuleSet, IvyModu
     }
 
     /**
-     * Called by {@link IvyModule#doDoDelete(StaplerRequest, StaplerResponse)}.
+     * Called by {@link IvyModule#doDoDelete(StaplerRequest2, StaplerResponse2)}.
      * Real deletion is done by the caller, and this method only adjusts the
      * data structure the parent maintains.
      */
@@ -471,7 +471,7 @@ public final class IvyModuleSet extends AbstractIvyProject<IvyModuleSet, IvyModu
     }
 
     @Override
-    public Object getDynamic(String token, StaplerRequest req, StaplerResponse rsp) {
+    public Object getDynamic(String token, StaplerRequest2 req, StaplerResponse2 rsp) {
         if (ModuleName.isValid(token)) {
             return getModule(token);
         }
@@ -694,7 +694,8 @@ public final class IvyModuleSet extends AbstractIvyProject<IvyModuleSet, IvyModu
     //
 
     @Override
-    protected void submit(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException, FormException {
+    protected void submit(StaplerRequest2 req, StaplerResponse2 rsp)
+            throws IOException, ServletException, FormException {
         super.submit(req, rsp);
         JSONObject json = req.getSubmittedForm();
 
@@ -746,7 +747,7 @@ public final class IvyModuleSet extends AbstractIvyProject<IvyModuleSet, IvyModu
      * Delete all disabled modules.
      */
     @POST
-    public void doDoDeleteAllDisabledModules(StaplerResponse rsp) throws IOException, InterruptedException {
+    public void doDoDeleteAllDisabledModules(StaplerResponse2 rsp) throws IOException, InterruptedException {
         checkPermission(DELETE);
         for (IvyModule m : getDisabledModules(true)) {
             m.delete();
@@ -857,7 +858,7 @@ public final class IvyModuleSet extends AbstractIvyProject<IvyModuleSet, IvyModu
         }
 
         @Override
-        public boolean configure(StaplerRequest req, JSONObject json) {
+        public boolean configure(StaplerRequest2 req, JSONObject json) {
             req.bindJSON(this, json);
             save();
 

--- a/src/main/java/hudson/ivy/IvyModuleSetBuild.java
+++ b/src/main/java/hudson/ivy/IvyModuleSetBuild.java
@@ -84,8 +84,8 @@ import org.apache.tools.ant.types.FileSet;
 import org.jenkinsci.lib.configprovider.model.Config;
 import org.jenkinsci.plugins.configfiles.ConfigFiles;
 import org.jenkinsci.plugins.configfiles.common.CleanTempFilesAction;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 
 /**
  * {@link Build} for {@link IvyModuleSet}.
@@ -224,7 +224,7 @@ public class IvyModuleSetBuild extends AbstractIvyBuild<IvyModuleSet, IvyModuleS
     }
 
     @Override
-    public Object getDynamic(String token, StaplerRequest req, StaplerResponse rsp) {
+    public Object getDynamic(String token, StaplerRequest2 req, StaplerResponse2 rsp) {
         // map corresponding module build under this object
         if (token.indexOf('$') > 0) {
             IvyModule m = getProject().getModule(token);

--- a/src/main/java/hudson/ivy/IvyReporterDescriptor.java
+++ b/src/main/java/hudson/ivy/IvyReporterDescriptor.java
@@ -29,7 +29,6 @@ import java.util.Collection;
 import jenkins.model.Jenkins;
 import org.apache.commons.jelly.JellyException;
 import org.kohsuke.stapler.MetaClass;
-import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.WebApp;
 import org.kohsuke.stapler.jelly.JellyClassTearOff;
 
@@ -78,7 +77,7 @@ public abstract class IvyReporterDescriptor extends Descriptor<IvyReporter> {
      */
     @Override
     @Deprecated
-    public IvyReporter newInstance(StaplerRequest req) throws FormException {
+    public IvyReporter newInstance(org.kohsuke.stapler.StaplerRequest req) throws FormException {
         return null;
     }
 


### PR DESCRIPTION
## Require Jenkins 2.479.1 and Jakarta EE 9

Reviewed dependent plugins and found no usages of the modified APIs.  Plugins that were reviewed:

* Ivy Report
* Artifactory
* Environment Injector
* Multi-Branch Project Plugin (DEPRECATED)
* Release
* scripted Cloud

Retained one deprecated method signature StaplerRequest for

  IvyReporterDescriptor.newInstance(org.kohsuke.stapler.StaplerRequest req)

since that method unconditionally returned null before and should be harmless to continue returning null.  

### Testing done

Unpacked https://dlcdn.apache.org//ant/ivy/2.5.3/apache-ivy-2.5.3-bin-with-deps.tar.gz and copied the ivy-2.5.3.jar file and all the lib/* files into the lib directory of my Apache Ant installation.  Created a freestyle project that users Apache Ivy to build src/test/resources/example-project/modules.

Confirmed a sample https://github.com/MarkEWaite/ant-ivy-java-example.git passes from the adapt-to-latest-ivy branch

Automated tests pass on Java 21.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
